### PR TITLE
UniRx のバージョン名を変更

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       }
     },
     "@umm/unirx": {
-      "version": "github:umm-projects/unirx#8ded122cd432aa0b3c8ea44b53953d308e416406",
+      "version": "github:umm-projects/unirx#ec0fa3564b189c13331ed9b703c768254f0ffcd6",
       "requires": {
         "glob": "7.1.2",
         "mkdirp": "0.5.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   ],
   "dependencies": {
     "@umm/accessor_utility_core": "github:umm-projects/accessor_utility_core#semver:^1.0.8",
-    "@umm/unirx": "github:umm-projects/unirx#semver:^5.5.4",
+    "@umm/unirx": "github:umm-projects/unirx#semver:^1.0.0",
     "glob": "^7.1.2",
     "mkdirp": "^0.5.1",
     "ncp": "^2.0.0",


### PR DESCRIPTION
* `@umm/unirx` のバージョニングルールを変更したので、記載バージョンを変更します。